### PR TITLE
Update nginx to use stable image

### DIFF
--- a/dify-deployment.yaml
+++ b/dify-deployment.yaml
@@ -1240,7 +1240,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: dify-nginx
-        image: nginx:latest
+        image: nginx:stable
         resources:
           requests:
             cpu: 50m

--- a/dify-mirror-deployment.yaml
+++ b/dify-mirror-deployment.yaml
@@ -1205,7 +1205,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: dify-nginx
-        image: dhub.kubesre.xyz/nginx:latest
+        image: dhub.kubesre.xyz/nginx:stable
         resources:
           requests:
             cpu: 50m

--- a/dify/network/nginx.yaml
+++ b/dify/network/nginx.yaml
@@ -150,6 +150,6 @@ spec:
         - name: dify-nginx
           configMap:
             name: dify-nginx
-        # Persistent volume could be better    
+        # Persistent volume could be better
         - name: dify-nginx-config
           emptyDir: {}

--- a/dify/network/nginx.yaml
+++ b/dify/network/nginx.yaml
@@ -129,7 +129,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: dify-nginx
-          image: nginx:latest
+          image: nginx:stable
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## What this PR does
The current configuration sets the nginx image to latest. Considering that this application may be used in production environments, it seems unnecessary to take the risk of unexpected bugs or access issues that could arise from using the latest version. Instead, I have updated the configuration to specify the stable version (stable), which is officially recommended for production servers.

Reference: [NGINX Documentation - Choosing Between a Stable or a Mainline Version](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#choosing-between-a-stable-or-a-mainline-version)

>ref: https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#choosing-between-a-stable-or-a-mainline-version
>## Choosing Between a Stable or a Mainline Version
>NGINX Open Source is available in two versions:
>
>- **Mainline** – Includes the latest features and bug fixes and is always up to date. It is reliable, but it may include some experimental modules, and it may also have some number of new bugs.
>- **Stable** – Doesn’t include all of the latest features, but has critical bug fixes that are always backported to the mainline version. We recommend the stable version for production servers.