### PR TITLE
Fix: Resolve Celery and Weaviate URL variable expansion issue in dify-deployment.yamlfix(deploy): fix redis and weaviate env error

### DIFF
--- a/dify-deployment.yaml
+++ b/dify-deployment.yaml
@@ -85,7 +85,7 @@ data:
   REDIS_USE_CLUSTERS: 'false'
   REDIS_CLUSTERS: ''
   REDIS_CLUSTERS_PASSWORD: ''
-  CELERY_BROKER_URL: 'redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)/1'
+  CELERY_BROKER_URL: 'redis://:difyai123456@dify-redis:6379/1'
   BROKER_USE_SSL: 'false'
   CELERY_USE_SENTINEL: 'false'
   CELERY_SENTINEL_MASTER_NAME: ''
@@ -142,7 +142,7 @@ data:
   # SUPABASE_API_KEY: ${SUPABASE_API_KEY:-your-access-key}
   # SUPABASE_URL: ${SUPABASE_URL:-your-server-url}
   VECTOR_STORE: weaviate
-  WEAVIATE_ENDPOINT: 'http://$(WEAVIATE_HOST):$(WEAVIATE_PORT)'
+  WEAVIATE_ENDPOINT: 'http://dify-weaviate:8080'
   WEAVIATE_API_KEY: WVF5YThaHlkYwhGUSmCRgsX3tD5ngdN8pkih
   # QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
   # QDRANT_API_KEY: ${QDRANT_API_KEY:-difyai123456}
@@ -1456,7 +1456,7 @@ spec:
 
         - name: CELERY_BROKER_URL
           value: >-
-              redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)/1
+              redis://:difyai123456@dify-redis:6379/1
  
         - name: SENTRY_DSN
           # value: ''
@@ -1946,7 +1946,7 @@ spec:
 
         - name: CELERY_BROKER_URL
           value: >-
-            redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)/1
+            redis://:difyai123456@dify-redis:6379/1
         - name: 'DB_DATABASE'
           # value: 'dify_plugin'
           valueFrom:


### PR DESCRIPTION
**Type:** Bug Fix

**Related Issue:**   #42 

**Background:**

In the `dify-kubernetes/dify-deployment.yaml` configuration file, the `CELERY_BROKER_URL` and `WEAVIATE_ENDPOINT` within the `dify-shared-config` ConfigMap were originally configured using `$(VARIABLE)` placeholders. The expectation was that these variables would be dynamically substituted based on other key-value pairs within the same ConfigMap. However, Kubernetes ConfigMap's `data` field does not inherently support this type of in-string variable substitution. This resulted in applications receiving URL strings containing unexpanded placeholders, preventing them from correctly connecting to the respective services (Redis and Weaviate) and impacting the normal functionality of the Dify application.

**Changes in this PR:**

To address the aforementioned variable expansion failure, this commit modifies the following configuration items within the `dify-shared-config` ConfigMap:

1.  **`CELERY_BROKER_URL`**:
    *   **Original Value**: `'redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)/1'`
    *   **Modified Value**: `'redis://:difyai123456@dify-redis:6379/1'`
        *   **Explanation**: This change replaces the placeholders in the URL with direct references based on Kubernetes service discovery and explicit values defined in `dify-shared-config`.
            *   `$(REDIS_HOST)` is replaced with the Kubernetes service name `dify-redis`.
            *   `$(REDIS_PORT)` is replaced with the port `6379`.
            *   `$(REDIS_PASSWORD)` is replaced with the actual password `difyai123456` (from the `REDIS_PASSWORD` key).
            *   `$(REDIS_USERNAME)` corresponds to an empty string (from the `REDIS_USERNAME` key), hence only a colon precedes the password in the URL.

2.  **`WEAVIATE_ENDPOINT`**:
    *   **Original Value**: (Likely in a form similar to `'http://$(WEAVIATE_HOST):$(WEAVIATE_PORT)'`, which failed due to unexpanded placeholders)
    *   **Modified Value**: `'http://dify-weaviate:8080'`
        *   **Explanation**: This change replaces the placeholders in the URL with a direct reference to the Weaviate Kubernetes service name (`dify-weaviate`) and its service port (`8080`).

**Reason for Change:**

The `$(VARIABLE)` syntax used within the ConfigMap data values in the original configuration is not automatically parsed and substituted by Kubernetes. Consequently, applications received literal strings containing these placeholders, leading to an inability to establish valid connections to the Celery Broker (Redis) and Weaviate services.

By modifying these URLs to use Kubernetes internal service DNS names and the intended ports/credentials, this ensures that Dify's API and Worker components, among others, receive correct and operational connection addresses.

**Impact on Users:**

This modification will fix issues related to service unavailability or functional abnormalities in Dify within a Kubernetes environment that were caused by incorrect Celery Broker and Weaviate connection configurations. After deploying this update, the relevant components of the Dify application should be ableto connect to these backend services more reliably and function normally.

**Testing:**

*   (It is recommended that you briefly describe here how you verified that this change is effective, e.g., deployed on a local Minikube/Kind cluster or development environment and passed all service health checks, or performed specific functional tests to confirm successful connections.)

**Additional Notes:**

*   Regarding the direct embedding of the password (`difyai123456`) in `CELERY_BROKER_URL`: While this password value itself is also stored in the `REDIS_PASSWORD` key of `dify-shared-config`, a more secure practice is generally to store sensitive information (like passwords) in Kubernetes Secrets. These Secret values can then be injected into Pod environment variables via `valueFrom: secretKeyRef`, and the full connection URL can be dynamically constructed in the application's startup script or code logic. The current modification primarily focuses on resolving the immediate variable substitution issue; further enhancements to credential management can be considered in the future.