### PR TITLE
upgrade `dify-plugin-daemon` to 0.3.0

### DIFF
--- a/dify-deployment.yaml
+++ b/dify-deployment.yaml
@@ -2037,7 +2037,7 @@ spec:
         command: [ 'sh', '-c', 'until pg_isready -h dify-postgres -U postgres -d dify; do echo waiting for postgres; sleep 2; done;' ]
       containers:
       - name: dify-plugin-daemon
-        image: langgenius/dify-plugin-daemon:0.1.0-local
+        image: langgenius/dify-plugin-daemon:0.3.0-local
         resources:
           limits:
             memory: "1024Mi"

--- a/dify-mirror-deployment.yaml
+++ b/dify-mirror-deployment.yaml
@@ -2036,7 +2036,7 @@ spec:
         command: [ 'sh', '-c', 'until pg_isready -h dify-postgres -U postgres -d mydb; do echo waiting for postgres; sleep 2; done;' ]
       containers:
       - name: dify-plugin-daemon
-        image: dhub.kubesre.xyz/langgenius/dify-plugin-daemon:0.1.0-local
+        image: dhub.kubesre.xyz/langgenius/dify-plugin-daemon:0.3.0-local
         resources:
           limits:
             memory: "1024Mi"


### PR DESCRIPTION
#56 The issue is caused by version incompatibility; in 1.9.1, the corresponding dify-plugin-daemon is 0.3.0.